### PR TITLE
Remove trips with only one stop from stop_times

### DIFF
--- a/diet_gtfs.py
+++ b/diet_gtfs.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import csv
 import sys
 
@@ -44,6 +45,8 @@ def clean_shapes(shape_ids):
 def process_stop_times(stop_ids):
     trip_ids = set()
 
+    trip_id_count = Counter()
+
     with open('stop_times.txt', 'r') as f:
         reader = csv.reader(f)
         filtered_rows = []
@@ -52,11 +55,21 @@ def process_stop_times(stop_ids):
         for row in reader:
             if row[2] in stop_ids:
                 filtered_rows.append(row)
-                trip_ids.add(row[0])
+                trip_id_count[row[0]] += 1
+
+        for trip_id, count in trip_id_count.items():
+            if count >= 2:
+                trip_ids.add(trip_id)
+
+        cleaned_rows = [filtered_rows[0]]
+
+        for row in filtered_rows[1:]:
+            if row[0] in trip_ids:
+                cleaned_rows.append(row)
 
     with open('cleaned/stop_times.txt', 'w') as f:
         writer = csv.writer(f)
-        writer.writerows(filtered_rows)
+        writer.writerows(cleaned_rows)
 
     return trip_ids
 


### PR DESCRIPTION
To fix the situation, I think, arising from having one stop in the
geographical range of interest, but then all others outside of it. This
throws up lots of warnings in validation.

Now we throw these away as they're useless anyway.

So, what we should be keeping now are whole trips internally within a
selected region, and the parts of trips that go outside a selected
region. (The latter makes sense, they're still useful trips since we
could go from A to B in a region, but not be bothered about going to C
outside that region, if we want to consider all public transport options
within a geographic region.)